### PR TITLE
Replaced JDK link to an OpenJDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Serverless Application Model Command Line Interface (SAM CLI) is an extensio
 To use the SAM CLI, you need the following tools.
 
 * SAM CLI - [Install the SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-* Java8 - [Install the Java SE Development Kit 8](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+* Java8 - [Install the Adopt Open JDK 8](https://adoptopenjdk.net/releases.html)
 * Maven - [Install Maven](https://maven.apache.org/install.html)
 * Docker - [Install Docker community edition](https://hub.docker.com/search/?type=edition&offering=community)
 


### PR DESCRIPTION
Oracle have changed there licenses in 2019 which restrict the usage and download of the JDK. Therefore you need to have an Oracle Dev account to download and use the JDK from Oracle. This is critical for Open Source devs as the licenses are not very permissive. I therefore request to change the download link to the Adopt OpenJDK which has way more permissive licenses and doesn't require a login.